### PR TITLE
Investigate Budget Comparison reports usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,7 +107,8 @@ def main():
         'resanalytics_unit_availability': 'resanalytics_unit_availability' in raw_data,
         'pending_make_ready': 'pending_make_ready' in raw_data,
         'resaranalytics_delinquency': 'resaranalytics_delinquency' in raw_data,
-        'residents_on_notice': 'residents_on_notice' in raw_data
+        'residents_on_notice': 'residents_on_notice' in raw_data,
+        'budget_comparison': 'budget_comparison' in raw_data
     }
     
 
@@ -198,10 +199,15 @@ def main():
         if make_ready_data is not None and not make_ready_data.empty:
             make_ready_count = len(make_ready_data)
     
-    # Calculate collections rate
+    # Calculate collections rate (using Budget Comparison + Delinquency data)
     collections_rate = 0.0
     if file_availability['resaranalytics_delinquency']:
-        collections_rate = calculate_collections_rate(raw_data['resaranalytics_delinquency'], box_metrics)
+        budget_comparison_data = raw_data.get('budget_comparison') if file_availability.get('budget_comparison') else None
+        collections_rate = calculate_collections_rate(
+            raw_data['resaranalytics_delinquency'],
+            box_metrics,
+            budget_comparison_data
+        )
     
     # Get traffic metrics
     traffic_metrics = get_traffic_metrics(raw_data.get('resanalytics_box_score', {}))


### PR DESCRIPTION
Implemented the correct collections rate formula as per documentation:
- Step 1: Calculate Charges from Budget Comparison (Total Income - Bad Debt - Write Off Rent)
- Step 2: Extract 0-30 Day Delinquency from delinquency reports
- Step 3: Calculate % Collected = (Charges - 0-30 Day Delinquency) / Charges

Changes:
- Added extract_budget_line_item() to extract financial line items from Budget Comparison
- Updated calculate_collections_rate() to accept Budget Comparison data
- Modified app.py to pass Budget Comparison data to collections calculation
- Maintained backward compatibility with fallback to old formula if Budget Comparison unavailable

This fixes the issue where Budget Comparison reports were parsed but never used, and the collections rate was incorrectly calculated using non-existent "Total Owed" column.